### PR TITLE
FIX: Ensure the module works with silverstripers/markdown module

### DIFF
--- a/src/model/CookiePolicyPageController.php
+++ b/src/model/CookiePolicyPageController.php
@@ -45,6 +45,13 @@ class CookiePolicyPageController extends PageController
             $hasLocation = stristr($this->Content, '$CookieConsentForm');
             if ($hasLocation) {
                 $content = preg_replace('/(<p[^>]*>)?\\$CookieConsentForm(<\\/p>)?/i', $form->forTemplate(), $this->Content);
+
+                // Remove leading whitespace.  This is an edge case, but if the module silverstripers/markdown is
+                // installed, the form fails to render.  The reason is that 1) The HTML for the form is injected into
+                // the output as HTMLText object  2) And HTMLText that has 4 or more spaces as a prefix is treated as
+                // being code content.  This broke the form rendering
+                $content = implode("\n", array_map('trim', explode("\n", $content)));
+
                 return array(
                     'Content' => DBField::create_field('HTMLText', $content),
                     'Form' => ""


### PR DESCRIPTION
This one was a real headbanger.  The form failed to render for me, escaping some of the form HTML and placing it inside `<pre><code>` tags.  After experimenting with different HTML content in `CookiePolicyPageController` I eventually realised that 4 leading spaces was the problem, and then twigged that the module `silverstripers/markdown` was the cause.  This PR simply removes leading and trailing whitespace from each line of the injected form.  The lack of 4 leading spaces means that the form renders, and it should of course not affect the form rendering when the markdown module is not installed.